### PR TITLE
Feature/better errors for get service required

### DIFF
--- a/src/Ninject.Web.AspNetCore.Test/Unit/ServiceProviderTest.cs
+++ b/src/Ninject.Web.AspNetCore.Test/Unit/ServiceProviderTest.cs
@@ -1,0 +1,147 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Ninject.Web.AspNetCore.Test.Fakes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Ninject.Web.AspNetCore.Test.Unit
+{
+	public class ServiceProviderTest
+	{
+				
+		[Fact]
+		public void ServiceProviderCreatedSuccessfully()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			NinjectServiceProviderBuilder builder = CreateServiceProviderBuilder(kernel);
+
+			var provider = builder.Build();
+			
+			provider.Should().NotBeNull().And.BeOfType(typeof(NinjectServiceProvider));
+		}		
+
+		[Fact]
+		public void OptionalExistingSingleServiceResolved()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			kernel.Bind<IWarrior>().To<Samurai>();
+			var provider = CreateServiceProvider(kernel);
+			
+			provider.GetService(typeof(IWarrior)).Should().NotBeNull().And.BeOfType(typeof(Samurai));
+		}
+
+		[Fact]
+		public void OptionalNonExistingSingleServiceResolvedToNull()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			var provider = CreateServiceProvider(kernel);
+			
+			provider.GetService(typeof(IWarrior)).Should().BeNull();
+		}
+
+		[Fact]
+		public void OptionalExistingMultipleServicesResolvedQueriedAsList()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			kernel.Bind<IWarrior>().To<Samurai>();
+			kernel.Bind<IWarrior>().ToConstant(new Ninja("test"));
+			var provider = CreateServiceProvider(kernel);
+			
+			var result = provider.GetService(typeof(IList<IWarrior>)) as IEnumerable<IWarrior>;
+			
+			result.Should().NotBeNull();
+			var resultList = result.ToList();
+			resultList.Should().HaveCount(2);
+			resultList.Should().Contain(x => x is Samurai);
+			resultList.Should().Contain(x => x is Ninja);
+		}
+
+		[Fact]
+		public void OptionalExistingMultipleServicesNotResolvedWhenNotQueriedAsList()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			kernel.Bind<IWarrior>().To<Samurai>();
+			kernel.Bind<IWarrior>().ToConstant(new Ninja("test"));
+			var provider = CreateServiceProvider(kernel);
+
+			provider.GetService(typeof(IWarrior)).Should().BeNull();			
+		}
+
+		[Fact]
+		public void RequiredExistingSingleServiceResolved()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			kernel.Bind<IWarrior>().To<Samurai>();
+			var provider = CreateServiceProvider(kernel);
+
+			provider.GetRequiredService(typeof(IWarrior)).Should().NotBeNull().And.BeOfType(typeof(Samurai));
+		}
+
+		[Fact]
+		public void RequiredNonExistingSingleServiceResolvedToException()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			var provider = CreateServiceProvider(kernel);
+
+			Action action = () => provider.GetRequiredService(typeof(IWarrior));
+			action.Should().Throw<ActivationException>().WithMessage("*No matching bindings are available*");
+		}
+
+		[Fact]
+		public void RequiredExistingMultipleServicesResolvedQueriedAsList()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			kernel.Bind<IWarrior>().To<Samurai>();
+			kernel.Bind<IWarrior>().ToConstant(new Ninja("test"));
+			var provider = CreateServiceProvider(kernel);
+
+			var result = provider.GetRequiredService(typeof(IList<IWarrior>)) as IEnumerable<IWarrior>;
+
+			result.Should().NotBeNull();
+			var resultList = result.ToList();
+			resultList.Should().HaveCount(2);
+			resultList.Should().Contain(x => x is Samurai);
+			resultList.Should().Contain(x => x is Ninja);
+		}
+
+		[Fact]
+		public void RequiredExistingMultipleServicesResolvedToExceptionWhenNotQueriedAsList()
+		{
+			StandardKernel kernel = CreateTestKernel();
+			kernel.Bind<IWarrior>().To<Samurai>();
+			kernel.Bind<IWarrior>().ToConstant(new Ninja("test"));
+			var provider = CreateServiceProvider(kernel);
+
+			Action action = () => provider.GetRequiredService(typeof(IWarrior));
+			action.Should().Throw<ActivationException>().WithMessage("*More than one matching bindings are availabl*");
+		}
+
+		private IServiceProvider CreateServiceProvider(IKernel kernel)
+		{
+			NinjectServiceProviderBuilder builder = CreateServiceProviderBuilder(kernel);
+			var provider = builder.Build();
+			return provider;
+		}
+
+		private NinjectServiceProviderBuilder CreateServiceProviderBuilder(IKernel kernel)
+		{
+			var collection = new ServiceCollection();
+			var factory = new NinjectServiceProviderFactory(kernel);
+			var builder = factory.CreateBuilder(collection);
+			return builder;
+		}
+
+		private StandardKernel CreateTestKernel()
+		{
+			var kernel = new StandardKernel(new NinjectSettings() { LoadExtensions = false });
+			kernel.Load(typeof(AspNetCoreApplicationPlugin).Assembly);
+			return kernel;
+		}
+
+
+
+
+	}
+}

--- a/src/Ninject.Web.AspNetCore/NinjectServiceProvider.cs
+++ b/src/Ninject.Web.AspNetCore/NinjectServiceProvider.cs
@@ -1,21 +1,31 @@
-﻿using System;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Ninject.Web.AspNetCore
 {
 	/// <summary>
 	/// We have to wrap IKernel here as an IServiceProvider,
-	/// although Ninject would itself implement this interface (but with a wrong semantic for the not found case).
-	///
-	/// Note: Although ASP.NET Core wants to use a method from ISupportRequiredService
-	/// we don't need to implement it as there is an extension method based on IServiceProvider.
+	/// although Ninject would itself implement this interface (but with a wrong semantic for the not found case) 
+	/// and additionally we want to implement the optional ISupportRequiredService.
+	/// 
+	/// Note: ASP.NET Core wants to use a method from ISupportRequiredService to resolve a non-optional service.
+	/// Although it's implemented on Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions in a generic way
+	/// we implement it here to have the nicer exceptions from NInject so that it's possible to distinguish the "not registered at all"
+	/// vs the "ambigious matches found" cases.
 	/// </summary>
-	public class NinjectServiceProvider : IServiceProvider
+	public class NinjectServiceProvider : IServiceProvider, ISupportRequiredService
 	{
 		private readonly IKernel _kernel;
 		
 		public NinjectServiceProvider(IKernel kernel)
 		{
 			_kernel = kernel;
+		}
+
+		public object GetRequiredService(Type serviceType)
+		{
+			var result = _kernel.Get(serviceType);
+			return result;
 		}
 
 		public object GetService(Type serviceType)

--- a/src/Ninject.Web.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Ninject.Web.AspNetCore/ServiceCollectionExtensions.cs
@@ -9,8 +9,7 @@ namespace Ninject.Web.AspNetCore
 	public static class ServiceCollectionExtensions
 	{
 		/// <summary>
-		/// Adds the <see cref="NinjectServiceProviderFactory"/> to the service collection. ONLY FOR PRE-ASP.NET 3.0 HOSTING. THIS WON'T WORK
-		/// FOR ASP.NET CORE 3.0+ OR GENERIC HOSTING.
+		/// Adds the <see cref="NinjectServiceProviderFactory"/> to the service collection. 
 		/// </summary>
 		/// <param name="services">The service collection to add the factory to.</param>
 		/// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>


### PR DESCRIPTION
Implement ISupportRequiredService to be able to debug Ninject binding issues in a better way.