### PR TITLE
Using the correct (scoped) IServiceProvider for implementation factories

### DIFF
--- a/src/Ninject.Web.AspNetCore.Test/Unit/ServiceProviderScopeTest.cs
+++ b/src/Ninject.Web.AspNetCore.Test/Unit/ServiceProviderScopeTest.cs
@@ -1,0 +1,67 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Ninject.Web.AspNetCore.Test.Fakes;
+using Xunit;
+
+namespace Ninject.Web.AspNetCore.Test.Unit;
+
+public class ServiceProviderScopeTest : TestKernelContext
+{
+	[Theory]
+	[MemberData(nameof(ServiceConfigurations))]
+	public void ScopedServices_ResolvedInScope_ShouldBeDifferent(ServiceCollection serviceCollection)
+	{
+		var kernel = CreateKernel(serviceCollection);
+		var provider = kernel.Get<IServiceProvider>();
+
+		var rootKnight = provider.GetRequiredService<Knight>();
+
+		using (var scope = provider.CreateScope())
+		{
+			// The IWeapon instantiated inside of this scope should also be tied to this scope when created through
+			// a ServiceDescriptor.ImplementationFactory
+			var levelOneKnight = scope.ServiceProvider.GetRequiredService<Knight>();
+			AssertNotSameKnightAndWeapon(levelOneKnight, rootKnight);
+			
+			var levelOneKnight2 = scope.ServiceProvider.GetRequiredService<Knight>();
+			AssertSameKnightAndWeapon(levelOneKnight2, levelOneKnight);
+		}
+
+		var rootKnight2 = provider.GetRequiredService<Knight>();
+		AssertSameKnightAndWeapon(rootKnight2, rootKnight);
+	}
+
+	private void AssertSameKnightAndWeapon(Knight value, Knight expected)
+	{
+		value.Should().BeSameAs(expected);
+		value.Weapon.Should().BeSameAs(expected.Weapon);
+	}
+	
+	private void AssertNotSameKnightAndWeapon(Knight value, Knight expected)
+	{
+		value.Should().NotBeSameAs(expected);
+		value.Weapon.Should().NotBeSameAs(expected.Weapon);
+	}
+	
+	public static TheoryData<ServiceCollection> ServiceConfigurations => new TheoryData<ServiceCollection>
+	{
+		{
+			new ServiceCollection() {
+				new ServiceDescriptor(typeof(Knight), typeof(Knight), ServiceLifetime.Scoped),
+				new ServiceDescriptor(typeof(IWeapon), typeof(Longsword), ServiceLifetime.Scoped)
+			}
+		},
+		{
+			new ServiceCollection() {
+				new ServiceDescriptor(typeof(Knight), typeof(Knight), ServiceLifetime.Scoped),
+				new ServiceDescriptor(typeof(Longsword), typeof(Longsword), ServiceLifetime.Scoped),
+				// See https://github.com/lord-executor/Ninject.Web.AspNetCore/issues/12
+				// The difference here is the use of a descriptor with an implementation factory where the implementation
+				// must make sure that the correct _scoped_ IServiceProvider instance is passed to the factory
+				new ServiceDescriptor(typeof(IWeapon),serviceProvider => serviceProvider.GetService<Longsword>(), ServiceLifetime.Scoped)
+			}
+		},
+	};
+}

--- a/src/Ninject.Web.AspNetCore/AspNetCoreApplicationPlugin.cs
+++ b/src/Ninject.Web.AspNetCore/AspNetCoreApplicationPlugin.cs
@@ -19,7 +19,7 @@ namespace Ninject.Web.AspNetCore
 			// when being instantiated through the ServiceProviderScopeResolutionRoot, the parameter for explicit nested scopes
 			// created through IServiceScopeFactory.CreateScope has precedence in order to preserve the behavior that is expected
 			// from IServiceProvider with scoped services.
-			var scope = context.Parameters.OfType<ServiceProviderScopeParameter>().SingleOrDefault()?.GetValue(context, null);
+			var scope = context.GetServiceProviderScopeParameter()?.GetValue(context, null);
 			// returns the currently active request scope. Used when binding with scope InRequestScope.
 			return scope ?? RequestScope.Current ?? throw new ActivationException("Trying to activate a service InRequestScope without a request scope present");
 		}

--- a/src/Ninject.Web.AspNetCore/ContextExtensions.cs
+++ b/src/Ninject.Web.AspNetCore/ContextExtensions.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using Ninject.Activation;
+
+namespace Ninject.Web.AspNetCore
+{
+	/// <summary>
+	/// Extension methods on <see cref="IContext"/> to simplify dealing with the <see cref="ServiceProviderScopeParameter" />
+	/// </summary>
+	public static class ContextExtensions
+	{
+		/// <summary>
+		/// Gets the <see cref="ServiceProviderScopeParameter"/> from the context parameters.
+		/// </summary>
+		/// <param name="context">The resolution context from which to retrieve the scope parameter</param>
+		/// <returns>The scope from which the request originated or <c>null</c> if there is none</returns>
+		public static ServiceProviderScopeParameter GetServiceProviderScopeParameter(this IContext context)
+		{
+			return context.Parameters.OfType<ServiceProviderScopeParameter>().SingleOrDefault();
+		}
+	}
+}

--- a/src/Ninject.Web.AspNetCore/NinjectServiceProviderBuilder.cs
+++ b/src/Ninject.Web.AspNetCore/NinjectServiceProviderBuilder.cs
@@ -25,7 +25,7 @@ namespace Ninject.Web.AspNetCore
 				// It essentially always injects the instance that is being used for the instantiation
 				// which kinda makes sense, but is not documented ANYWHERE, not tested ANYWHERE and was really quite difficult to
 				// figure out.
-				var scopeProvider = context.Parameters.OfType<ServiceProviderScopeParameter>().SingleOrDefault()?.SourceServiceProvider;
+				var scopeProvider = context.GetServiceProviderScopeParameter()?.SourceServiceProvider;
 				if (scopeProvider != null)
 				{
 					var descriptor = context.Request.ParentContext?.Binding.Metadata.Get<ServiceDescriptor>(nameof(ServiceDescriptor));


### PR DESCRIPTION
I eventually tracked down the problem to the `ServiceCollectionAdapter`. Specifically to the case of a `ServiceDescriptor` with an `ImplementationFactory`. Something that I obviously overlooked before. Just like in the `NinjectServiceProviderBuilder`, we have to use the appropriate _scoped_ `IServiceProvider` instance - the one _of the scope_ where the service is being created in.

The old implementation just used `context.Kernel.Get<IServiceProvider>()` which of course always resolves to the "root" `IServiceProvider`. This PR fixes that by getting the scoped `IServiceProvider` from the resolution context and only falling back to the "root" service provider for cases that use the kernel directly.

In the Blazor sample application, the `RemoteNavigationManager` is of course such an `ImplementationFactory` service which was then incorrectly always resolved from the root service provider.