### PR TITLE
Update to .NET 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: .NET 8 CI
+name: .NET 9 CI
 on: [push]
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         name: Setup .NET SDK
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Build
         run: dotnet build src/Ninject.Web.AspNetCore.sln -c Release

--- a/README.md
+++ b/README.md
@@ -268,9 +268,10 @@ This is comparatively easy to fix by replacing the Ninject default `OpenGenericB
 # Versioning
 The package version numbers are chosen to align with the version of ASP.NET Core they were built against.
 
-| Version | ASP.NET Core Version | Ninject Version | Target Frameworks  | Notes |
-|---------|----------------------|-----------------|--------------------|-------|
-| 8.*     | 8.0                  | 3.3.4           | net8.0, net7.0, net6.0, net5.0     | The current _mainline_ version for use together with ASP.NET Core 8, 7, 6 or 5 |
-| 5.*     | 5.0                  | 3.3.4           | net5.0             | Old NET 5 version. Obsolete now and included in 7.* line |
-| 3.0.*   | 3.0.*, 3.1.*         | 3.3.4           | netcoreapp3.0, netcoreapp3.1  | The last .NET Core version. No longer maintained. |
-| 2.2.*   | 2.2.*                | 3.3.4           | netstandard2.0, netcoreapp2.2 | Should only be used as a "transitional" version when migrating to more recent .NET Core versions. No longer maintained. |
+| Version | ASP.NET Core Version | Ninject Version | Target Frameworks              | Notes                                                                                                                   |
+|---------|----------------------|-----------------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| 9.*     | 9.0                  | 3.3.4           | net9.0, net8.0                 | The current _mainline_ version for use together with ASP.NET Core 9 and 8                                               |
+| 8.*     | 8.0                  | 3.3.4           | net8.0, net7.0, net6.0, net5.0 | "v-prev" with support for ASP.NET Core 8, 7, 6 or 5                                                                     |
+| 5.*     | 5.0                  | 3.3.4           | net5.0                         | Old NET 5 version. Obsolete now and included in 7.* line                                                                |
+| 3.0.*   | 3.0.*, 3.1.*         | 3.3.4           | netcoreapp3.0, netcoreapp3.1   | The last .NET Core version. No longer maintained.                                                                       |
+| 2.2.*   | 2.2.*                | 3.3.4           | netstandard2.0, netcoreapp2.2  | Should only be used as a "transitional" version when migrating to more recent .NET Core versions. No longer maintained. |

--- a/src/Ninject.Web.AspNetCore.ComplianceTest/Ninject.Web.AspNetCore.ComplianceTest.csproj
+++ b/src/Ninject.Web.AspNetCore.ComplianceTest/Ninject.Web.AspNetCore.ComplianceTest.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Ninject.Web.AspNetCore.Httpsys/Ninject.Web.AspNetCore.HttpSys.csproj
+++ b/src/Ninject.Web.AspNetCore.Httpsys/Ninject.Web.AspNetCore.HttpSys.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <RootNamespace>Ninject.Web.AspNetCore</RootNamespace>
     <PackageProjectUrl>https://github.com/lord-executor/Ninject.Web.AspNetCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/lord-executor/Ninject.Web.AspNetCore</RepositoryUrl>

--- a/src/Ninject.Web.AspNetCore.IIS/Ninject.Web.AspNetCore.IIS.csproj
+++ b/src/Ninject.Web.AspNetCore.IIS/Ninject.Web.AspNetCore.IIS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <RootNamespace>Ninject.Web.AspNetCore</RootNamespace>
     <PackageProjectUrl>https://github.com/lord-executor/Ninject.Web.AspNetCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/lord-executor/Ninject.Web.AspNetCore</RepositoryUrl>

--- a/src/Ninject.Web.AspNetCore.Test/Ninject.Web.AspNetCore.Test.csproj
+++ b/src/Ninject.Web.AspNetCore.Test/Ninject.Web.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -9,14 +9,14 @@
     <PackageReference Include="Ninject" Version="3.3.6" />
     <PackageReference Include="Ninject.Web.Common" Version="3.3.2" />
     <PackageReference Include="Ninject.Web.Common.SelfHost" Version="3.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ninject.Web.AspNetCore/Ninject.Web.AspNetCore.csproj
+++ b/src/Ninject.Web.AspNetCore/Ninject.Web.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/lord-executor/Ninject.Web.AspNetCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/lord-executor/Ninject.Web.AspNetCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/SampleApplication/SampleApplication.csproj
+++ b/src/SampleApplication/SampleApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <DebugType>full</DebugType>
     <RootNamespace>SampleApplication</RootNamespace>

--- a/src/SampleBlazorApplication/SampleBlazorApplication.csproj
+++ b/src/SampleBlazorApplication/SampleBlazorApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
Update to .NET 9, including update of all dependencies to their latest versions. This also limits support for the 9.0.0 version to .NET 9 and .NET 8.